### PR TITLE
Enable google colab launch button

### DIFF
--- a/Tutorial 0 - Overview.ipynb
+++ b/Tutorial 0 - Overview.ipynb
@@ -147,6 +147,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {

--- a/Tutorial 1 - TMY Weather Data.ipynb
+++ b/Tutorial 1 - TMY Weather Data.ipynb
@@ -123,6 +123,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {

--- a/Tutorial 2 - POA Irradiance.ipynb
+++ b/Tutorial 2 - POA Irradiance.ipynb
@@ -81,6 +81,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/Tutorial 3 - Array Power.ipynb
+++ b/Tutorial 3 - Array Power.ipynb
@@ -38,6 +38,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/Tutorial A - Single Diode Model.ipynb
+++ b/Tutorial A - Single Diode Model.ipynb
@@ -15,6 +15,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/Tutorial B - pvfree.ipynb
+++ b/Tutorial B - pvfree.ipynb
@@ -23,6 +23,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [

--- a/Tutorial C - Modeling Module's Performance Advanced.ipynb
+++ b/Tutorial C - Modeling Module's Performance Advanced.ipynb
@@ -94,6 +94,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/Tutorial D - pySAM Modeling the Bifacial Tracker Field at NREL.ipynb
+++ b/Tutorial D - pySAM Modeling the Bifacial Tracker Field at NREL.ipynb
@@ -26,6 +26,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "a1ada6cc-8ed9-4568-8959-111d81ef4e9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if running on google colab, uncomment the next line and execute this cell to install the dependencies and prevent \"ModuleNotFoundError\" in later cells:\n",
+    "# !pip install -r https://raw.githubusercontent.com/PVSC-Python-Tutorials/PVPMC_2022/main/requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "ca7b8b3c",
    "metadata": {},

--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,4 @@ html:
 launch_buttons:
   jupyterhub_url: "https://pvsc-python-tutorial.eastus.cloudapp.azure.com"
   thebe: true
+  colab_url: "https://colab.research.google.com"


### PR DESCRIPTION
I tried out google colab as an alternative to mybinder and our TLJH server.  It seemed to work pretty well -- nice and snappy when loading notebooks, although it doesn't automatically initialize our custom python environment.  I think the only way to get that working is by calling `!pip install ...` in the notebooks themselves, which I've added some helper cells to do.  

With this PR, there's a new entry in the rocket ship menu:

![image](https://user-images.githubusercontent.com/57452607/187961282-6d02edae-f212-4aeb-a503-da0ef1380734.png)
