### PR TITLE
Remove "Launch on JupyterHub" button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,5 @@ html:
   use_repository_button: true
 
 launch_buttons:
-  jupyterhub_url: "https://pvsc-python-tutorial.eastus.cloudapp.azure.com"
   thebe: true
   colab_url: "https://colab.research.google.com"


### PR DESCRIPTION
This PR removes the "launch on jupyterhub" button.  If others agree this is a good idea, we can do the same for the other repositories. 